### PR TITLE
Update widgets styling

### DIFF
--- a/packages/widgets/src/components/nk-connect-wallet-button/nk-connect-wallet-button.scss
+++ b/packages/widgets/src/components/nk-connect-wallet-button/nk-connect-wallet-button.scss
@@ -1,9 +1,8 @@
-@use "@material/theme"with ($primary: #2196F3,
+@use "@material/theme"with ($primary: #000,
 );
 @use "@material/typography"with ($font-family: unquote("Chivo, Roboto, sans-serif"),
   $styles-button: (text-transform: uppercase,
-    font-size: 14px,
-    font-style: 0.875rem,
+    font-size: 0.9375rem,
     font-weight: bold,
     line-height: 1.75,
     letter-spacing: 0.4px,

--- a/packages/widgets/src/components/nk-connect-wallet-button/readme.md
+++ b/packages/widgets/src/components/nk-connect-wallet-button/readme.md
@@ -7,12 +7,29 @@
 
 ## Shadow Parts
 
-| Part                     | Description |
-| ------------------------ | ----------- |
-| `"wallet-btn"`           |             |
-| `"wallet-btn-container"` |             |
+| Part                     | Description                                       |
+| ------------------------ | ------------------------------------------------- |
+| `"wallet-btn"`           | Button for connecting to a cryptocurrency wallet. |
+| `"wallet-btn-container"` | Container that wraps the wallet button.           |
 
 
+## Examples of overriding styles:
+
+`
+nk-connect-wallet-button::part(wallet-btn-container) {  
+    margin: 20px auto;  
+    display: block;  
+}
+`
+  
+`
+nk-connect-wallet-button::part(wallet-btn) {  
+    width: 300px;  
+    height: 50px;  
+    background: red;  
+}
+`
+  
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/widgets/src/components/nk-connect-wallet-button/readme.md
+++ b/packages/widgets/src/components/nk-connect-wallet-button/readme.md
@@ -14,6 +14,8 @@
 
 
 ## Examples of overriding styles:
+  
+Add any overrides inside a `style` tag in your html `head`.
 
     nk-connect-wallet-button::part(wallet-btn-container) {  
         margin: 20px auto;  

--- a/packages/widgets/src/components/nk-connect-wallet-button/readme.md
+++ b/packages/widgets/src/components/nk-connect-wallet-button/readme.md
@@ -15,20 +15,16 @@
 
 ## Examples of overriding styles:
 
-`
-nk-connect-wallet-button::part(wallet-btn-container) {  
-    margin: 20px auto;  
-    display: block;  
-}
-`
-  
-`
-nk-connect-wallet-button::part(wallet-btn) {  
-    width: 300px;  
-    height: 50px;  
-    background: red;  
-}
-`
+    nk-connect-wallet-button::part(wallet-btn-container) {  
+        margin: 20px auto;  
+        display: block;  
+    }
+
+    nk-connect-wallet-button::part(wallet-btn) {  
+        width: 300px;  
+        height: 50px;  
+        background: red;  
+    }
   
 ----------------------------------------------
 

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
@@ -31,6 +31,10 @@
     width: 100%;
   }
 
+  .mdc-select__selected-text {
+    font-size: 0.975rem;
+  }
+
   .mdc-floating-label,
   .mdc-select__selected-text {
     text-align: center;
@@ -51,7 +55,7 @@
 
 .mdc-select:not(.mdc-select--disabled) {
   .mdc-select__anchor {
-    background-color: #2196F3;
+    background-color: #000;
   }
 
   .mdc-floating-label,
@@ -78,4 +82,28 @@
   .mdc-select__dropdown-icon {
     fill: rgba(0, 0, 0, 0.38);
   }
+}
+
+.mdc-menu-surface,
+.mdc-select--filled .mdc-menu-surface--is-open-below {
+  border-radius: 16px;
+  box-shadow: 0 0 20px 4px rgba(0,0,0,0.1);
+}
+
+.mdc-select__menu .mdc-deprecated-list
+.mdc-deprecated-list-item.mdc-deprecated-list-item--selected
+.mdc-deprecated-list-item__ripple::before,
+.mdc-select__menu .mdc-deprecated-list
+.mdc-deprecated-list-item.mdc-deprecated-list-item--selected
+.mdc-deprecated-list-item__ripple::after {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.mdc-deprecated-list-item
+:not(.mdc-deprecated-list-item--disabled).mdc-deprecated-list-item
+.mdc-deprecated-list-item__ripple::before,
+.mdc-deprecated-list-item
+:not(.mdc-deprecated-list-item--disabled).mdc-deprecated-list-item
+.mdc-deprecated-list-item__ripple::after {
+  background-color: rgba(0, 0, 0, 0.4);
 }

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
@@ -28,10 +28,12 @@
     min-width: 156px;
     min-height: 36px;
     width: 100%;
+    height: 36px;
   }
 
   .mdc-select__selected-text {
     font-size: 0.975rem;
+    position: relative;
   }
 
   .mdc-floating-label,
@@ -48,7 +50,9 @@
   }
 
   nk-loading {
-    margin-top: -17px;
+    position: absolute;
+    top: 0;
+    left: calc(50% - 12px);
   }
 }
 

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
@@ -27,7 +27,6 @@
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.14), 0px 1px 5px rgba(0, 0, 0, 0.12);
     min-width: 156px;
     min-height: 36px;
-    max-height: 36px;
     width: 100%;
   }
 

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
@@ -5,6 +5,17 @@ import Swal from 'sweetalert2';
 import { handleError } from '../../utils/errors';
 import state from '../../stores/wallet';
 
+const swalWithCustomStyles = Swal.mixin({
+  customClass: {
+    actions: 'custom-swal-actions',
+    confirmButton: 'custom-swal-button',
+    htmlContainer: 'custom-swal-html',
+    popup: 'custom-swal-popup',
+    title: 'custom-swal-title',
+  },
+  buttonsStyling: false,
+});
+
 @Component({
   tag: 'nk-drop-mint-button',
   styleUrl: 'nk-drop-mint-button.scss',
@@ -97,7 +108,7 @@ export class NKDropMintButton {
 
         await tx.wait();
 
-        await Swal.fire({
+        await swalWithCustomStyles.fire({
           title: this.successTitle,
           text: this.successMessage,
         });
@@ -110,7 +121,7 @@ export class NKDropMintButton {
 
         await tx.wait();
 
-        await Swal.fire({
+        await swalWithCustomStyles.fire({
           title: this.successTitle,
           text: this.successMessage,
         });
@@ -121,7 +132,7 @@ export class NKDropMintButton {
       throw new Error('Sale is not active.');
     } catch (err) {
       console.log(err);
-      await Swal.fire({
+      await swalWithCustomStyles.fire({
         title: 'Error',
         text: handleError(err.message),
       });

--- a/packages/widgets/src/components/nk-drop-mint-button/readme.md
+++ b/packages/widgets/src/components/nk-drop-mint-button/readme.md
@@ -28,13 +28,43 @@ Type: `Promise<void>`
 
 ## Shadow Parts
 
-| Part                   | Description |
-| ---------------------- | ----------- |
-| `"mint-btn"`           |             |
-| `"mint-btn-container"` |             |
-| `"mint-dropdown-icon"` |             |
-| `"mint-text"`          |             |
+| Part                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `"mint-btn"`           | Button for selecting the number of items and triggering the mint action. |
+| `"mint-btn-container"` | Containing element wrapper for the mint button.                          |
+| `"mint-dropdown-icon"` | Icon for the mint button.                                                |
+| `"mint-text"`          | Descriptive button text for the user action.                             |
 
+
+## Examples of overriding styles:
+
+`
+nk-drop-mint-button::part(mint-btn-container) {  
+    width: 300px;  
+    height: 42px;  
+}  
+`
+  
+`
+nk-drop-mint-button::part(mint-btn) {  
+    height: 42px;  
+    background: red;  
+}  
+`
+  
+`
+nk-drop-mint-button::part(mint-text) {  
+    font-size: 18px;  
+}  
+`
+  
+`
+nk-drop-mint-button::part(mint-dropdown-icon) {  
+    width: 32px;  
+    height: 32px;  
+    fill: black;  
+}  
+`
 
 ----------------------------------------------
 

--- a/packages/widgets/src/components/nk-drop-mint-button/readme.md
+++ b/packages/widgets/src/components/nk-drop-mint-button/readme.md
@@ -37,7 +37,9 @@ Type: `Promise<void>`
 
 
 ## Examples of overriding styles:
-
+  
+Add any overrides inside a `style` tag in your html `head`.
+  
     nk-drop-mint-button::part(mint-btn-container) {  
         width: 300px;  
         height: 42px;  

--- a/packages/widgets/src/components/nk-drop-mint-button/readme.md
+++ b/packages/widgets/src/components/nk-drop-mint-button/readme.md
@@ -38,33 +38,25 @@ Type: `Promise<void>`
 
 ## Examples of overriding styles:
 
-`
-nk-drop-mint-button::part(mint-btn-container) {  
-    width: 300px;  
-    height: 42px;  
-}  
-`
+    nk-drop-mint-button::part(mint-btn-container) {  
+        width: 300px;  
+        height: 42px;  
+    }  
   
-`
-nk-drop-mint-button::part(mint-btn) {  
-    height: 42px;  
-    background: red;  
-}  
-`
+    nk-drop-mint-button::part(mint-btn) {  
+        height: 42px;  
+        background: red;  
+    }  
   
-`
-nk-drop-mint-button::part(mint-text) {  
-    font-size: 18px;  
-}  
-`
+    nk-drop-mint-button::part(mint-text) {  
+        font-size: 18px;  
+    }  
   
-`
-nk-drop-mint-button::part(mint-dropdown-icon) {  
-    width: 32px;  
-    height: 32px;  
-    fill: black;  
-}  
-`
+    nk-drop-mint-button::part(mint-dropdown-icon) {  
+        width: 32px;  
+        height: 32px;  
+        fill: black;  
+    }  
 
 ----------------------------------------------
 

--- a/packages/widgets/src/components/nk-loading/nk-loading.scss
+++ b/packages/widgets/src/components/nk-loading/nk-loading.scss
@@ -1,4 +1,4 @@
-@use "@material/theme"with ($primary: rgba(0, 0, 0, 0.38),
+@use "@material/theme"with ($primary: rgba(255, 255, 255, 0.8),
 );
 @use "@material/circular-progress/mdc-circular-progress";
 

--- a/packages/widgets/src/global/global.scss
+++ b/packages/widgets/src/global/global.scss
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Chivo:wght@400;700&display=swap');
 
 html {
-    font-family: Chivo, sans-serif;
+    font-family: 'Chivo', sans-serif;
     font-weight: 400;
 }
 
@@ -39,6 +39,7 @@ html {
         background-color: #2196F3;
         border-color: transparent;
         color: white;
+        font-family: inherit;
         font-size: 0.875rem;
         font-weight: 700;
         text-transform: uppercase;

--- a/packages/widgets/src/global/global.scss
+++ b/packages/widgets/src/global/global.scss
@@ -1,0 +1,48 @@
+@import url('https://fonts.googleapis.com/css2?family=Chivo:wght@400;700&display=swap');
+
+html {
+    font-family: Chivo, sans-serif;
+    font-weight: 400;
+}
+
+.swal2-container {
+    .custom-swal-popup {
+        border-radius: 0;
+    }
+
+    .custom-swal-title {
+        margin: .8rem 1.5rem 0;
+        padding: 0;
+        color: rgba(0, 0, 0, 0.87);
+        font-size: 20px;
+        text-align: left;
+    }
+
+    .custom-swal-html {
+        margin: .8rem 1.5rem;
+        padding: 0;
+        color: rgba(0, 0, 0, 0.87);
+        font-size: 1rem;
+        text-align: left;
+    }
+
+    .custom-swal-actions {
+        width: 100%;
+        padding: 0 1.5rem;
+    }
+
+    .custom-swal-button {
+        width: 100%;
+        min-height: 36px;
+        box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.14), 0px 1px 5px rgba(0, 0, 0, 0.12);
+        border-radius: 28px;
+        background-color: #2196F3;
+        border-color: transparent;
+        color: white;
+        font-size: 0.875rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        cursor: pointer;
+        outline: none;
+    }
+}

--- a/packages/widgets/src/index.html
+++ b/packages/widgets/src/index.html
@@ -36,8 +36,8 @@
       }
     </style> -->
   </head>
-  <body style="text-align: center;">
-    <nk-diamond collection-id="clg4bffey0004yjucsgtbp8rl" is-dev="true">
+  <body>
+    <nk-diamond collection-id="clg9wuwjd00019e384ck7vauc" is-dev="true">
       <nk-connect-wallet-button>
         Connect Wallet
       </nk-connect-wallet-button>

--- a/packages/widgets/src/index.html
+++ b/packages/widgets/src/index.html
@@ -6,6 +6,7 @@
     <title>Stencil Component Starter</title>
     <script type="module" src="/build/widgets.esm.js"></script>
     <script nomodule src="/build/widgets.js"></script>
+    <link rel="stylesheet" href="/build/widgets.css" />
   </head>
   <body>
     <nk-diamond collection-id="clg9wuwjd00019e384ck7vauc" is-dev="true">

--- a/packages/widgets/src/index.html
+++ b/packages/widgets/src/index.html
@@ -7,6 +7,34 @@
     <script type="module" src="/build/widgets.esm.js"></script>
     <script nomodule src="/build/widgets.js"></script>
     <link rel="stylesheet" href="/build/widgets.css" />
+    <!-- <style>
+      nk-connect-wallet-button::part(wallet-btn-container) {
+        margin: 20px auto;
+        display: block;
+      }
+      nk-connect-wallet-button::part(wallet-btn) {
+        width: 300px;
+        height: 50px;
+        background: #553d9d;
+      }
+      nk-drop-mint-button::part(mint-btn-container) {
+        width: 300px;
+        height: 42px;
+      }
+      nk-drop-mint-button::part(mint-btn) {
+        height: 80px;
+        background: #553d9d;
+        border-radius: 40px;
+      }
+      nk-drop-mint-button::part(mint-text) {
+        font-size: 36px;
+      }
+      nk-drop-mint-button::part(mint-dropdown-icon) {
+        width: 32px;
+        height: 32px;
+        fill: black;
+      }
+    </style> -->
   </head>
   <body style="text-align: center;">
     <nk-diamond collection-id="clg4bffey0004yjucsgtbp8rl" is-dev="true">

--- a/packages/widgets/src/index.html
+++ b/packages/widgets/src/index.html
@@ -8,8 +8,8 @@
     <script nomodule src="/build/widgets.js"></script>
     <link rel="stylesheet" href="/build/widgets.css" />
   </head>
-  <body>
-    <nk-diamond collection-id="clg9wuwjd00019e384ck7vauc" is-dev="true">
+  <body style="text-align: center;">
+    <nk-diamond collection-id="clg4bffey0004yjucsgtbp8rl" is-dev="true">
       <nk-connect-wallet-button>
         Connect Wallet
       </nk-connect-wallet-button>

--- a/packages/widgets/src/stores/wallet.ts
+++ b/packages/widgets/src/stores/wallet.ts
@@ -56,6 +56,13 @@ export async function initialize(
   state.modal = new Web3Modal(
     {
       projectId,
+      themeVariables: {
+        '--w3m-font-family': 'Chivo, sans-serif',
+        '--w3m-accent-color': '#000',
+        '--w3m-background-color': '#000',
+        '--w3m-background-border-radius': '16px',
+        '--w3m-container-border-radius': '16px',
+      },
     },
     state.client
   );

--- a/packages/widgets/src/stores/wallet.ts
+++ b/packages/widgets/src/stores/wallet.ts
@@ -58,7 +58,6 @@ export async function initialize(
       projectId,
       themeVariables: {
         '--w3m-font-family': 'Chivo, sans-serif',
-        '--w3m-accent-color': '#000',
         '--w3m-background-color': '#000',
         '--w3m-background-border-radius': '16px',
         '--w3m-container-border-radius': '16px',

--- a/packages/widgets/stencil.config.ts
+++ b/packages/widgets/stencil.config.ts
@@ -11,6 +11,7 @@ export const config: Config = {
   env: {
     projectId: process.env.PROJECT_ID,
   },
+  globalStyle: 'src/global/global.scss',
   rollupPlugins: {
     before: [
       rollupCommonjs({


### PR DESCRIPTION
Update widgets styling
Update WalletConnect base styling
Added some customization instructions to readme

User has dark mode:
<img width="408" alt="Screenshot 2023-04-10 at 5 26 12 PM" src="https://user-images.githubusercontent.com/1714294/231024528-dec95dfd-632e-4bfe-b9fa-064ef69cc086.png">

Default (light mode):
<img width="397" alt="Screenshot 2023-04-10 at 5 27 16 PM" src="https://user-images.githubusercontent.com/1714294/231024530-51f09042-46c5-402a-a905-5d3ee4c3dba3.png">


<img width="433" alt="Screenshot 2023-04-10 at 5 01 27 PM" src="https://user-images.githubusercontent.com/1714294/231023223-237418e0-aa5b-4dbe-a150-ba8db5b58905.png">

<img width="272" alt="Screenshot 2023-04-10 at 5 02 29 PM" src="https://user-images.githubusercontent.com/1714294/231023225-b25dd7e0-3d4f-47af-b9be-21a7992b8495.png">

<img width="615" alt="Screenshot 2023-04-10 at 5 12 00 PM" src="https://user-images.githubusercontent.com/1714294/231023226-1c473971-47b7-4242-a8ac-ab8d28b3a546.png">
