### PR TITLE
Add success link option on mint success dialog

### DIFF
--- a/packages/widgets/src/components.d.ts
+++ b/packages/widgets/src/components.d.ts
@@ -50,6 +50,14 @@ export namespace Components {
          */
         "projectId": string;
         /**
+          * Link on the success modal
+         */
+        "successLink"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successLinkText"?: string;
+        /**
           * Body message on the success modal
          */
         "successMessage": string;
@@ -84,6 +92,14 @@ export namespace Components {
         "editionId": number;
         "mint": (quantity: number) => Promise<void>;
         /**
+          * Link on the success modal
+         */
+        "successLink"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successLinkText"?: string;
+        /**
           * Body message on the success modal
          */
         "successMessage": string;
@@ -106,6 +122,14 @@ export namespace Components {
           * Crossmint Project Id
          */
         "projectId": string;
+        /**
+          * Link on the success modal
+         */
+        "successLink"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successLinkText"?: string;
         /**
           * Body message on the success modal
          */
@@ -299,6 +323,14 @@ declare namespace LocalJSX {
          */
         "projectId": string;
         /**
+          * Link on the success modal
+         */
+        "successLink"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successLinkText"?: string;
+        /**
           * Body message on the success modal
          */
         "successMessage"?: string;
@@ -331,6 +363,14 @@ declare namespace LocalJSX {
          */
         "editionId": number;
         /**
+          * Link on the success modal
+         */
+        "successLink"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successLinkText"?: string;
+        /**
           * Body message on the success modal
          */
         "successMessage"?: string;
@@ -352,6 +392,14 @@ declare namespace LocalJSX {
           * Crossmint Project Id
          */
         "projectId": string;
+        /**
+          * Link on the success modal
+         */
+        "successLink"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successLinkText"?: string;
         /**
           * Body message on the success modal
          */

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
@@ -46,6 +46,8 @@ export class NKDropMintButton {
 
   @State() mintSuccess = false;
 
+  @State() isMinting = false;
+
   /**
    * Title on the success modal
    */
@@ -155,7 +157,7 @@ export class NKDropMintButton {
           { length: this.maxPerMint },
           (_, i) => i + 1
         );
-        this.loading = false;
+        this.loading = this.isMinting;
         // sale not active then disable widget
         this.disabled = !(this.saleActive || this.presaleActive);
       }
@@ -187,6 +189,8 @@ export class NKDropMintButton {
   async mint(quantity: number) {
     try {
       this.loading = true;
+      this.mintSuccess = false;
+      this.isMinting = true;
       const address = state.walletClient?.account?.address;
       const chainId = await state.walletClient?.getChainId();
       if (chainId !== state.chain?.id) {
@@ -364,6 +368,7 @@ export class NKDropMintButton {
       this.dialogOpen = true;
     } finally {
       this.loading = false;
+      this.isMinting = false;
     }
   }
 

--- a/packages/widgets/src/components/nk-drop-mint-button/readme.md
+++ b/packages/widgets/src/components/nk-drop-mint-button/readme.md
@@ -7,10 +7,12 @@
 
 ## Properties
 
-| Property         | Attribute         | Description                       | Type     | Default                        |
-| ---------------- | ----------------- | --------------------------------- | -------- | ------------------------------ |
-| `successMessage` | `success-message` | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
-| `successTitle`   | `success-title`   | Title on the success modal        | `string` | `'Success'`                    |
+| Property          | Attribute           | Description                       | Type     | Default                        |
+| ----------------- | ------------------- | --------------------------------- | -------- | ------------------------------ |
+| `successLink`     | `success-link`      | Link on the success modal         | `string` | `''`                           |
+| `successLinkText` | `success-link-text` | Link text on the success modal    | `string` | `'here'`                       |
+| `successMessage`  | `success-message`   | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
+| `successTitle`    | `success-title`     | Title on the success modal        | `string` | `'Success'`                    |
 
 
 ## Methods

--- a/packages/widgets/src/components/nk-drop-mint-crossmint-button/nk-drop-mint-crossmint-button.tsx
+++ b/packages/widgets/src/components/nk-drop-mint-crossmint-button/nk-drop-mint-crossmint-button.tsx
@@ -20,6 +20,10 @@ export class NKDropMintCrossmintButton {
    */
   @Prop() collectionId!: string;
 
+  @State() mintSuccess = false;
+
+  @State() isMinting = false;
+
   /**
    * Title on the success modal
    */
@@ -29,6 +33,16 @@ export class NKDropMintCrossmintButton {
    * Body message on the success modal
    */
   @Prop() successMessage = 'Successfully minted an NFT';
+
+  /**
+   * Link text on the success modal
+   */
+  @Prop() successLinkText? = 'here';
+
+  /**
+   * Link on the success modal
+   */
+  @Prop() successLink? = '';
 
   @State() disabled = true;
 
@@ -104,7 +118,7 @@ export class NKDropMintCrossmintButton {
           ...this.mintConfig,
           totalPrice: ethers.utils.formatEther(price),
         };
-        this.loading = false;
+        this.loading = this.isMinting;
 
         // sale not active then disable widget
         this.disabled = !(this.saleActive || this.presaleActive);
@@ -156,6 +170,8 @@ export class NKDropMintCrossmintButton {
 
     if (loadingEvents.includes(type)) {
       this.loading = true;
+      this.isMinting = true;
+      this.mintSuccess = false;
     }
 
     if (successEvents.includes(type)) {
@@ -163,6 +179,8 @@ export class NKDropMintCrossmintButton {
       this.dialogMessage = this.successMessage;
       this.dialogOpen = true;
       this.loading = false;
+      this.isMinting = false;
+      this.mintSuccess = true;
     }
 
     if (failedEvents.includes(type)) {
@@ -170,6 +188,8 @@ export class NKDropMintCrossmintButton {
       this.dialogMessage = 'Payment failed';
       this.dialogOpen = true;
       this.loading = false;
+      this.isMinting = false;
+      this.mintSuccess = false;
     }
   };
 
@@ -205,6 +225,18 @@ export class NKDropMintCrossmintButton {
         </div>
         <nk-dialog open={this.dialogOpen} dialogTitle={this.dialogTitle}>
           {this.dialogMessage}
+          {this.mintSuccess && !!this.successLink && (
+            <span>
+              {' '}
+              <a
+                href={this.successLink}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'rgba(0,0,0,0.6)' }}>
+                {this.successLinkText}
+              </a>
+            </span>
+          )}
         </nk-dialog>
       </Host>
     );

--- a/packages/widgets/src/components/nk-drop-mint-crossmint-button/readme.md
+++ b/packages/widgets/src/components/nk-drop-mint-crossmint-button/readme.md
@@ -7,12 +7,14 @@
 
 ## Properties
 
-| Property                    | Attribute         | Description                       | Type     | Default                        |
-| --------------------------- | ----------------- | --------------------------------- | -------- | ------------------------------ |
-| `collectionId` _(required)_ | `collection-id`   | Crossmint Collection Id           | `string` | `undefined`                    |
-| `projectId` _(required)_    | `project-id`      | Crossmint Project Id              | `string` | `undefined`                    |
-| `successMessage`            | `success-message` | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
-| `successTitle`              | `success-title`   | Title on the success modal        | `string` | `'Success'`                    |
+| Property                    | Attribute           | Description                       | Type     | Default                        |
+| --------------------------- | ------------------- | --------------------------------- | -------- | ------------------------------ |
+| `collectionId` _(required)_ | `collection-id`     | Crossmint Collection Id           | `string` | `undefined`                    |
+| `projectId` _(required)_    | `project-id`        | Crossmint Project Id              | `string` | `undefined`                    |
+| `successLink`               | `success-link`      | Link on the success modal         | `string` | `''`                           |
+| `successLinkText`           | `success-link-text` | Link text on the success modal    | `string` | `'here'`                       |
+| `successMessage`            | `success-message`   | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
+| `successTitle`              | `success-title`     | Title on the success modal        | `string` | `'Success'`                    |
 
 
 ## Methods

--- a/packages/widgets/src/components/nk-edition-mint-button/nk-edition-mint-button.tsx
+++ b/packages/widgets/src/components/nk-edition-mint-button/nk-edition-mint-button.tsx
@@ -38,6 +38,10 @@ export class NKEditionMintButton {
    */
   @Prop() editionId!: number;
 
+  @State() mintSuccess = false;
+
+  @State() isMinting = false;
+
   /**
    * Title on the success modal
    */
@@ -47,6 +51,16 @@ export class NKEditionMintButton {
    * Body message on the success modal
    */
   @Prop() successMessage = 'Successfully minted an NFT';
+
+  /**
+   * Link text on the success modal
+   */
+  @Prop() successLinkText? = 'here';
+
+  /**
+   * Link on the success modal
+   */
+  @Prop() successLink? = '';
 
   container!: HTMLDivElement;
 
@@ -82,7 +96,7 @@ export class NKEditionMintButton {
           { length: this.maxPerMint },
           (_, i) => i + 1
         );
-        this.loading = false;
+        this.loading = this.isMinting;
 
         // sale not active then disable widget
         this.disabled = !this.active;
@@ -115,6 +129,8 @@ export class NKEditionMintButton {
   async mint(quantity: number) {
     try {
       this.loading = true;
+      this.isMinting = true;
+      this.mintSuccess = false;
       const address = state.walletClient?.account?.address;
       const chainId = await state.walletClient?.getChainId();
       if (chainId !== state.chain?.id) {
@@ -144,6 +160,7 @@ export class NKEditionMintButton {
 
         this.dialogTitle = this.successTitle;
         this.dialogMessage = this.successMessage;
+        this.mintSuccess = true;
         this.dialogOpen = true;
 
         return;
@@ -157,6 +174,7 @@ export class NKEditionMintButton {
       this.dialogOpen = true;
     } finally {
       this.loading = false;
+      this.isMinting = false;
     }
   }
 
@@ -234,6 +252,18 @@ export class NKEditionMintButton {
         </div>
         <nk-dialog open={this.dialogOpen} dialogTitle={this.dialogTitle}>
           {this.dialogMessage}
+          {this.mintSuccess && !!this.successLink && (
+            <span>
+              {' '}
+              <a
+                href={this.successLink}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'rgba(0,0,0,0.6)' }}>
+                {this.successLinkText}
+              </a>
+            </span>
+          )}
         </nk-dialog>
       </div>
     );

--- a/packages/widgets/src/components/nk-edition-mint-button/readme.md
+++ b/packages/widgets/src/components/nk-edition-mint-button/readme.md
@@ -7,11 +7,13 @@
 
 ## Properties
 
-| Property                 | Attribute         | Description                       | Type     | Default                        |
-| ------------------------ | ----------------- | --------------------------------- | -------- | ------------------------------ |
-| `editionId` _(required)_ | `edition-id`      | Edition ID                        | `number` | `undefined`                    |
-| `successMessage`         | `success-message` | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
-| `successTitle`           | `success-title`   | Title on the success modal        | `string` | `'Success'`                    |
+| Property                 | Attribute           | Description                       | Type     | Default                        |
+| ------------------------ | ------------------- | --------------------------------- | -------- | ------------------------------ |
+| `editionId` _(required)_ | `edition-id`        | Edition ID                        | `number` | `undefined`                    |
+| `successLink`            | `success-link`      | Link on the success modal         | `string` | `''`                           |
+| `successLinkText`        | `success-link-text` | Link text on the success modal    | `string` | `'here'`                       |
+| `successMessage`         | `success-message`   | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
+| `successTitle`           | `success-title`     | Title on the success modal        | `string` | `'Success'`                    |
 
 
 ## Methods

--- a/packages/widgets/src/components/nk-edition-mint-crossmint-button/nk-edition-mint-crossmint-button.tsx
+++ b/packages/widgets/src/components/nk-edition-mint-crossmint-button/nk-edition-mint-crossmint-button.tsx
@@ -24,6 +24,10 @@ export class NKEditionMintCrossmintButton {
    */
   @Prop() editionId!: number;
 
+  @State() mintSuccess = false;
+
+  @State() isMinting = false;
+
   /**
    * Title on the success modal
    */
@@ -33,6 +37,16 @@ export class NKEditionMintCrossmintButton {
    * Body message on the success modal
    */
   @Prop() successMessage = 'Successfully minted an NFT';
+
+  /**
+   * Link text on the success modal
+   */
+  @Prop() successLinkText? = 'here';
+
+  /**
+   * Link on the success modal
+   */
+  @Prop() successLink? = '';
 
   @State() disabled = true;
 
@@ -95,7 +109,7 @@ export class NKEditionMintCrossmintButton {
           totalPrice: ethers.utils.formatEther(price),
           proof,
         };
-        this.loading = false;
+        this.loading = this.isMinting;
 
         // sale not active then disable widget
         this.disabled = !this.active;
@@ -147,6 +161,10 @@ export class NKEditionMintCrossmintButton {
 
     if (loadingEvents.includes(type)) {
       this.loading = true;
+      this.isMinting = true;
+      this.mintSuccess = false;
+      this.isMinting = false;
+      this.mintSuccess = true;
     }
 
     if (successEvents.includes(type)) {
@@ -161,6 +179,8 @@ export class NKEditionMintCrossmintButton {
       this.dialogMessage = 'Payment failed';
       this.dialogOpen = true;
       this.loading = false;
+      this.isMinting = false;
+      this.mintSuccess = false;
     }
   };
 
@@ -196,6 +216,18 @@ export class NKEditionMintCrossmintButton {
         </div>
         <nk-dialog open={this.dialogOpen} dialogTitle={this.dialogTitle}>
           {this.dialogMessage}
+          {this.mintSuccess && !!this.successLink && (
+            <span>
+              {' '}
+              <a
+                href={this.successLink}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: 'rgba(0,0,0,0.6)' }}>
+                {this.successLinkText}
+              </a>
+            </span>
+          )}
         </nk-dialog>
       </Host>
     );

--- a/packages/widgets/src/components/nk-edition-mint-crossmint-button/readme.md
+++ b/packages/widgets/src/components/nk-edition-mint-crossmint-button/readme.md
@@ -7,13 +7,15 @@
 
 ## Properties
 
-| Property                    | Attribute         | Description                       | Type     | Default                        |
-| --------------------------- | ----------------- | --------------------------------- | -------- | ------------------------------ |
-| `collectionId` _(required)_ | `collection-id`   | Crossmint Collection Id           | `string` | `undefined`                    |
-| `editionId` _(required)_    | `edition-id`      | Edition Id                        | `number` | `undefined`                    |
-| `projectId` _(required)_    | `project-id`      | Crossmint Project Id              | `string` | `undefined`                    |
-| `successMessage`            | `success-message` | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
-| `successTitle`              | `success-title`   | Title on the success modal        | `string` | `'Success'`                    |
+| Property                    | Attribute           | Description                       | Type     | Default                        |
+| --------------------------- | ------------------- | --------------------------------- | -------- | ------------------------------ |
+| `collectionId` _(required)_ | `collection-id`     | Crossmint Collection Id           | `string` | `undefined`                    |
+| `editionId` _(required)_    | `edition-id`        | Edition Id                        | `number` | `undefined`                    |
+| `projectId` _(required)_    | `project-id`        | Crossmint Project Id              | `string` | `undefined`                    |
+| `successLink`               | `success-link`      | Link on the success modal         | `string` | `''`                           |
+| `successLinkText`           | `success-link-text` | Link text on the success modal    | `string` | `'here'`                       |
+| `successMessage`            | `success-message`   | Body message on the success modal | `string` | `'Successfully minted an NFT'` |
+| `successTitle`              | `success-title`     | Title on the success modal        | `string` | `'Success'`                    |
 
 
 ## Methods

--- a/packages/widgets/src/index.html
+++ b/packages/widgets/src/index.html
@@ -38,7 +38,7 @@
     </style> -->
   </head>
   <body>
-    <nk-diamond collection-id="clg9wuwjd00019e384ck7vauc" is-dev="true">
+    <nk-diamond collection-id="clrrv5ci80001snxtpryyv6hj" is-dev="true">
       <nk-connect-wallet-button> Connect Wallet </nk-connect-wallet-button>
       <nk-is-connected>
         <h3><nk-drop-supply-text /> Minted</h3>
@@ -50,12 +50,6 @@
           Mint NFT
         </nk-drop-mint-button>
         <br />
-        <nk-drop-mint-winter-button
-          project-id="12417"
-          success-title="Success!"
-          success-message="You did it!">
-          Mint With Credit Card (Winter)
-        </nk-drop-mint-winter-button>
       </nk-is-connected>
       <nk-is-holder>
         <h3>Thank you so much for being part of our membership!</h3>


### PR DESCRIPTION
If success-link is provided then the default success link text is 'here':
```
<nk-drop-mint-button
      success-title="Success!"
      success-message="You did it! View your Base NFT"
      success-link="https://app.niftykit.com/collections/base-diamonds">
      Mint NFT
</nk-drop-mint-button>
```
Optional to add custom success link text:
```
<nk-drop-mint-button
      success-title="Success!"
      success-message="You did it! View your Base NFT"
      success-link="https://app.niftykit.com/collections/base-diamonds"
      success-link-text="NOW">
      Mint NFT
</nk-drop-mint-button>
```

<img width="414" alt="Screenshot 2024-01-23 at 4 07 58 PM" src="https://github.com/niftykit-inc/niftykit-sdk/assets/1714294/da58d422-f505-4e3c-ae8e-3fd6870c17fd">

<img width="418" alt="Screenshot 2024-01-23 at 4 12 30 PM" src="https://github.com/niftykit-inc/niftykit-sdk/assets/1714294/e86a515c-51fa-447a-8a18-a0d87bb8390d">
