### PR TITLE
Add image success option, link to same success link if available

### DIFF
--- a/packages/widgets/src/components.d.ts
+++ b/packages/widgets/src/components.d.ts
@@ -23,7 +23,7 @@ export namespace Components {
     interface NkDropMintButton {
         "mint": (quantity: number) => Promise<void>;
         /**
-          * Link text on the success modal
+          * Image url for the success modal
          */
         "successImageUrl"?: string;
         /**
@@ -39,7 +39,7 @@ export namespace Components {
          */
         "successMessage": string;
         /**
-          * Link text on the success modal
+          * Align text on the success modal (default: left)
          */
         "successTextAlign"?: string;
         /**
@@ -305,7 +305,7 @@ declare namespace LocalJSX {
     }
     interface NkDropMintButton {
         /**
-          * Link text on the success modal
+          * Image url for the success modal
          */
         "successImageUrl"?: string;
         /**
@@ -321,7 +321,7 @@ declare namespace LocalJSX {
          */
         "successMessage"?: string;
         /**
-          * Link text on the success modal
+          * Align text on the success modal (default: left)
          */
         "successTextAlign"?: string;
         /**

--- a/packages/widgets/src/components.d.ts
+++ b/packages/widgets/src/components.d.ts
@@ -23,6 +23,10 @@ export namespace Components {
     interface NkDropMintButton {
         "mint": (quantity: number) => Promise<void>;
         /**
+          * Link text on the success modal
+         */
+        "successImageUrl"?: string;
+        /**
           * Link on the success modal
          */
         "successLink"?: string;
@@ -34,6 +38,10 @@ export namespace Components {
           * Body message on the success modal
          */
         "successMessage": string;
+        /**
+          * Link text on the success modal
+         */
+        "successTextAlign"?: string;
         /**
           * Title on the success modal
          */
@@ -297,6 +305,10 @@ declare namespace LocalJSX {
     }
     interface NkDropMintButton {
         /**
+          * Link text on the success modal
+         */
+        "successImageUrl"?: string;
+        /**
           * Link on the success modal
          */
         "successLink"?: string;
@@ -308,6 +320,10 @@ declare namespace LocalJSX {
           * Body message on the success modal
          */
         "successMessage"?: string;
+        /**
+          * Link text on the success modal
+         */
+        "successTextAlign"?: string;
         /**
           * Title on the success modal
          */

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.scss
@@ -27,6 +27,11 @@
   font-weight: 400;
 }
 
+.mdc-center-image {
+  margin: 8px auto;
+  text-align: center;
+}
+
 .mdc-select {
   .mdc-select__anchor {
     border-radius: 28px;

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
@@ -68,6 +68,16 @@ export class NKDropMintButton {
    */
   @Prop() successLink? = '';
 
+  /**
+   * Link text on the success modal
+   */
+  @Prop() successImageUrl? = '';
+
+  /**
+   * Link text on the success modal
+   */
+  @Prop() successTextAlign? = '';
+
   container!: HTMLDivElement;
 
   select: MDCSelect | null = null;
@@ -484,7 +494,31 @@ export class NKDropMintButton {
             ))}
           </ul>
         </div>
-        <nk-dialog open={this.dialogOpen} dialogTitle={this.dialogTitle}>
+        <nk-dialog
+          open={this.dialogOpen}
+          dialogTitle={this.dialogTitle}
+          style={{ textAlign: this.successTextAlign }}>
+          {!!this.successImageUrl && (
+            <div class="mdc-center-image">
+              {this.successLink ? (
+                <a href={this.successLink} target="_blank" rel="noreferrer">
+                  <img
+                    src={this.successImageUrl}
+                    alt={this.dialogMessage}
+                    width="300"
+                    height="300"
+                  />
+                </a>
+              ) : (
+                <img
+                  src={this.successImageUrl}
+                  alt={this.dialogMessage}
+                  width="300"
+                  height="300"
+                />
+              )}
+            </div>
+          )}
           {this.dialogMessage}
           {this.mintSuccess && !!this.successLink && (
             <span>

--- a/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
+++ b/packages/widgets/src/components/nk-drop-mint-button/nk-drop-mint-button.tsx
@@ -69,12 +69,12 @@ export class NKDropMintButton {
   @Prop() successLink? = '';
 
   /**
-   * Link text on the success modal
+   * Image url for the success modal
    */
   @Prop() successImageUrl? = '';
 
   /**
-   * Link text on the success modal
+   * Align text on the success modal (default: left)
    */
   @Prop() successTextAlign? = '';
 


### PR DESCRIPTION
Add option to include success image to dialog
use success link if provided
align success text option

`<nk-drop-mint-button
  success-title="Success!"
              success-message="You did it! View your Base NFT"
              success-link="https://app.niftykit.com/collections/base-diamonds"
              success-link-text="NOW"
              success-image-url="https://res.cloudinary.com/niftykit/image/fetch/f_auto/https://nftstorage.link/ipfs/bafybeiapr4vlfpruiw4eqly4bd24wnzfpfxhj25zuljn7udasi7yvzmxey"
              success-text-align="center"
              class="hydrated">
              Mint NFT
            </nk-drop-mint-button>`

<img width="425" alt="Screenshot 2024-01-25 at 12 31 37 PM" src="https://github.com/niftykit-inc/niftykit-sdk/assets/1714294/f20a79f6-8cc7-484d-9547-2882f23cd02e">
