### PR TITLE
Add quantity option to Pro Mint button unique mint link parameters

### DIFF
--- a/packages/diamond/src/Diamond.ts
+++ b/packages/diamond/src/Diamond.ts
@@ -207,10 +207,11 @@ export default class Diamond {
     collectionId: string,
     publicKey: string,
     isDev?: boolean,
-    unique?: boolean
+    unique?: boolean,
+    quantity?: number
   ): Promise<MintLinkApiResponse> {
     const baseUrl = isDev ? API_ENDPOINT_DEV : API_ENDPOINT;
-    const url = `${baseUrl}/onboarding/mintLinks/public/${publicKey}/${collectionId}?unique=${unique}`;
+    const url = `${baseUrl}/onboarding/mintLinks/public/${publicKey}/${collectionId}?unique=${unique}&quantity=${quantity}`;
     const resp = await axios.get<MintLinkApiResponse & ErrorApiResponse>(url, {
       validateStatus: (status) => status < 500,
     });

--- a/packages/widgets/src/components.d.ts
+++ b/packages/widgets/src/components.d.ts
@@ -181,6 +181,7 @@ export namespace Components {
           * Public Key
          */
         "publicKey": string;
+        "quantity"?: number;
         "unique"?: boolean;
     }
 }
@@ -478,6 +479,7 @@ declare namespace LocalJSX {
           * Public Key
          */
         "publicKey": string;
+        "quantity"?: number;
         "unique"?: boolean;
     }
     interface IntrinsicElements {

--- a/packages/widgets/src/components/nk-pro-mint-button/nk-pro-mint-button.tsx
+++ b/packages/widgets/src/components/nk-pro-mint-button/nk-pro-mint-button.tsx
@@ -22,6 +22,8 @@ export class NKProMintButton {
 
   @Prop() unique?: boolean;
 
+  @Prop() quantity?: number;
+
   @State() mintLinkId: string = null;
 
   container!: HTMLDivElement;
@@ -33,7 +35,8 @@ export class NKProMintButton {
       this.collectionId,
       this.publicKey,
       this.isDev,
-      this.unique
+      this.unique,
+      this.quantity
     );
 
     this.mintLinkId = data.id;

--- a/packages/widgets/src/stores/onboarding.ts
+++ b/packages/widgets/src/stores/onboarding.ts
@@ -15,13 +15,15 @@ export async function initialize(
   collectionId: string,
   publicKey: string,
   isDev?: boolean,
-  unique?: boolean
+  unique?: boolean,
+  quantity?: number
 ): Promise<MintLinkApiResponse> {
   const data = await Diamond.getMintLinkByPublicKey(
     collectionId,
     publicKey,
     isDev,
-    unique
+    unique,
+    quantity
   );
 
   if (!data) {


### PR DESCRIPTION
`<nk-diamond collection-id="clmr6rd4v0001yj5fdyctrnki" is-dev="true">
    <nk-pro-mint-button
      collection-id="clmr6rd4v0001yj5fdyctrnki"
      public-key="ttyledi"
      is-dev="true"
      unique="true"
      quantity="3">
      Mint Your Digital Collectible on NiftyKit
    </nk-pro-mint-button>
  </nk-diamond>`

For unique mint links, quantity is an option (default to 1) for maxAmount, maxPerWallet, maxPerTx:

<img width="1332" alt="Screenshot 2024-02-06 at 11 27 30 AM" src="https://github.com/niftykit-inc/niftykit-sdk/assets/1714294/ba918945-e8b7-411f-b524-cd9118a73923">
